### PR TITLE
update module name to be consistent with repo path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Masterminds/squirrel
+module github.com/xichen2020/squirrel
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
```go: github.com/xichen2020/squirrel@v1.1.1-0.20190911185535-b5dfe2e935d7: parsing go.mod: unexpected module path "github.com/Masterminds/squirrel"```